### PR TITLE
Two options that the default value doesn't match with texlab

### DIFF
--- a/package.json
+++ b/package.json
@@ -143,7 +143,7 @@
         },
         "texlab.formatterLineLength": {
           "type": "integer",
-          "default": 120,
+          "default": 80,
           "description": "Maximum amount of characters per line (0 = disable)."
         }
       }

--- a/package.json
+++ b/package.json
@@ -128,7 +128,7 @@
         },
         "texlab.chktex.onOpenAndSave": {
           "type": "boolean",
-          "default": true,
+          "default": false,
           "description": "Lint using chktex after opening and saving a file."
         },
         "texlab.chktex.onEdit": {


### PR DESCRIPTION
Hi!

I saw that in the `texlab` repository the option `chktex.onOpenAndSave` ([options.md](https://github.com/latex-lsp/texlab/blob/master/docs/options.md#texlabchktexonopenandsave)) has `false` as the default value and in this extension is `true`.
In the option `texlab.formatterLineLength` ([options.md](https://github.com/latex-lsp/texlab/blob/master/docs/options.md#texlabformatterlinelength)) the `texlab` repository has `80` as the default value and in this extension the default value is `120`.
I think that would be great to have the same options as there!
Thanks @fannheyward for all your work!