### PR TITLE
Fixed error TS2558: Expected 3 type arguments, but got 4

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -66,11 +66,11 @@ export interface ForwardSearchResult {
 }
 
 namespace BuildTextDocumentRequest {
-  export const type = new RequestType<BuildTextDocumentParams, BuildResult, void, void>('textDocument/build');
+  export const type = new RequestType<BuildTextDocumentParams, BuildResult, void>('textDocument/build');
 }
 
 namespace ForwardSearchRequest {
-  export const type = new RequestType<TextDocumentPositionParams, ForwardSearchResult, void, void>('textDocument/forwardSearch');
+  export const type = new RequestType<TextDocumentPositionParams, ForwardSearchResult, void>('textDocument/forwardSearch');
 }
 
 export class LatexLanguageClient extends LanguageClient {


### PR DESCRIPTION
Updated definitions:
-  ForwardSearchRequest.type
-  BuildTextDocumentRequest.type

`tsc` output:

```text
src/client.ts:69:39 - error TS2558: Expected 3 type arguments, but got 4.

69   export const type = new RequestType<BuildTextDocumentParams, BuildResult, void, void>('textDocument/build');
                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

src/client.ts:73:39 - error TS2558: Expected 3 type arguments, but got 4.

73   export const type = new RequestType<TextDocumentPositionParams, ForwardSearchResult, void, void>('textDocument/forwardSearch');
                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


Found 2 errors in the same file, starting at: src/client.ts:69
```

I opened latex document and macro autocompletion still work. I've tested this with the release branch of `coc.nvim` (https://github.com/neoclide/coc.nvim/commit/1782712d1f6ff74b029d57130a58ef78b6cdeebc).

P.S. I'm not sure why there are errors at all, but I just wanted to point out that _there are_ errors.